### PR TITLE
Updates to AbstractSpline.__init__ and NaturalCubicSpline._transform_array

### DIFF
--- a/basis_expansions/basis_expansions.py
+++ b/basis_expansions/basis_expansions.py
@@ -164,7 +164,7 @@ class Polynomial(BaseEstimator, TransformerMixin):
 class AbstractSpline(BaseEstimator, TransformerMixin):
     """Base class for all spline basis expansions."""
     def __init__(self, max=None, min=None, n_knots=None, n_params=None, knots=None):
-        if not knots:
+        if knots is None:
             if not n_knots:
                n_knots = self._compute_n_knots(n_params)
             knots = np.linspace(min, max, num=(n_knots + 2))[1:-1] 

--- a/basis_expansions/basis_expansions.py
+++ b/basis_expansions/basis_expansions.py
@@ -354,7 +354,10 @@ class NaturalCubicSpline(AbstractSpline):
 
     def _transform_array(self, X, **transform_params):
         X = X.squeeze()
-        X_spl = np.zeros((X.shape[0], self.n_knots - 1))
+        try:
+            X_spl = np.zeros((X.shape[0], self.n_knots - 1))
+        except IndexError:
+            X_spl = np.zeros((1, self.n_knots - 1))
         X_spl[:, 0] = X.squeeze()
 
         def d(knot_idx, x):


### PR DESCRIPTION
Hello,

Formerly passing a np.array to the knots parameter did crash the code. See for example:

```python
In [1]: import numpy as np

In [2]: knots = np.array([1,2,3])

In [3]: if not knots:
   ...:     print('Doing something')
   ...:
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-3-a2ac0d42392c> in <module>()
----> 1 if not knots:
      2     print('Doing something')
      3

ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()

In [4]:
```

Another issue was when trying to use a model made with NaturalCubicSpline to predict a value with only one element.

For example, see:

```python
In [1]: import numpy as np

In [2]: X = np.array([1]).squeeze()

In [3]: X_spl = np.zeros((X.shape[0],  5))
---------------------------------------------------------------------------
IndexError                                Traceback (most recent call last)
<ipython-input-3-bdcdcd1fd193> in <module>()
----> 1 X_spl = np.zeros((X.shape[0],  5))

IndexError: tuple index out of range
```

This was corrected using a the try-except pattern.
